### PR TITLE
add path dimension to FileUploadLatencyInSeconds metrics

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,13 +7,13 @@
 	"features": {
 		"ghcr.io/devcontainers/features/aws-cli:1": {},
 		"ghcr.io/devcontainers-contrib/features/aws-cdk:2": {}
-	}
+	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+	"forwardPorts": [9229]
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "yarn install",

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Changes need to be approved by product managers
-* @tetrascience/tetrascience-public-developers
+* @tetrascience/tetrascience-public-developers @tetrascience/agents

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Jest file",
+            "type": "node",
+            "request": "launch",
+            "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/jest",
+            "args": [
+                "${fileBasenameNoExtension}",
+                "--runInBand",
+                "--watch",
+                "--coverage=false",
+                "--no-cache"
+            ],
+            "cwd": "${workspaceRoot}",
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "sourceMaps": true,
+            "windows": {
+                "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+            }
+        },
+    ]
+}

--- a/bin/ts-agent-monitoring.ts
+++ b/bin/ts-agent-monitoring.ts
@@ -40,6 +40,8 @@ async function main() {
 
   new TsAgentMonitoringStack(app, 'TsAgentMonitoringStack', {
     agents,
+    tsApiUrl: tdpApiBaseUrl,
+    tsAuthToken: authToken,
     env: { account, region },
   })
 }

--- a/lib/ts-agent-monitoring-stack.fla-metrics-lambda.ts
+++ b/lib/ts-agent-monitoring-stack.fla-metrics-lambda.ts
@@ -1,10 +1,23 @@
 import { promisify } from 'util'
 import { gunzip } from 'zlib'
-import type { CloudWatchLogsDecodedData, CloudWatchLogsEvent } from 'aws-lambda'
-import { CloudWatch } from 'aws-sdk'
+import type { CloudWatchLogsDecodedData, CloudWatchLogsEvent, CloudWatchLogsLogEvent } from 'aws-lambda'
+import { CloudWatch, SecretsManager } from 'aws-sdk'
+import { createHash } from 'crypto'
+import axios from 'axios'
+
+const TETRASCIENCE_API_URL = process.env.TETRASCIENCE_API_URL
+const TETRASCIENCE_AUTH_TOKEN_SECRET_ARN = process.env.TETRASCIENCE_AUTH_TOKEN_SECRET_ARN || ''
 
 const cloudwatch = new CloudWatch()
+const secretsmanager = new SecretsManager()
+
 const gunzipAsync = promisify(gunzip)
+const configurationByAgentId: { [index: string]: { configurationChecksum: string; pathsTrie: PathTrieNode } } = {}
+
+interface AgentConfigurationApiResponse {
+  id: string
+  config: { services_configuration: { fileWatcher: { paths: { path: string }[] } } }
+}
 
 export async function handler(event: CloudWatchLogsEvent) {
   const payload = Buffer.from(event.awslogs.data, 'base64')
@@ -16,10 +29,46 @@ export async function handler(event: CloudWatchLogsEvent) {
     return
   }
 
+  await processEvents(logGroup, logEvents)
+}
+
+export async function processEvents(logGroup: string, logEvents: CloudWatchLogsLogEvent[]) {
   // log group is of the form /agents/<orgslug>/<agentid>
   const logGroupSegments = logGroup.substring(1).split('/')
   const orgSlug = logGroupSegments[1]
   const agentId = logGroupSegments[2]
+
+  // load fla agent configuration and construct trie to match paths
+  const authToken = await secretsmanager
+    .getSecretValue({ SecretId: TETRASCIENCE_AUTH_TOKEN_SECRET_ARN })
+    .promise()
+    .then((response) => response.SecretString)
+
+  if (!authToken) {
+    throw new Error(
+      'Tetrascience Auth Token not found in Secrets Manager.  Ensure it is set in Secrets Manager with ARN ' +
+        TETRASCIENCE_AUTH_TOKEN_SECRET_ARN,
+    )
+  }
+  const configuration = await getAgentConfiguration(orgSlug, authToken, agentId)
+  const configurationJson = JSON.stringify(configuration)
+  const configurationChecksum = createHash('md5').update(configurationJson).digest('hex')
+
+  if (
+    !configurationByAgentId[agentId] ||
+    configurationByAgentId[agentId].configurationChecksum !== configurationChecksum
+  ) {
+    const paths = configuration.config.services_configuration.fileWatcher.paths.map(
+      (fileWatcherPath: { path: string }) => fileWatcherPath.path,
+    )
+    const pathsTrie = buildPathsTrie(paths)
+    configurationByAgentId[agentId] = {
+      configurationChecksum: configurationChecksum,
+      pathsTrie: pathsTrie,
+    }
+  }
+
+  const pathsTrie = configurationByAgentId[agentId].pathsTrie
 
   for (const logEvent of logEvents) {
     const logMessageJson = JSON.parse(logEvent.message)
@@ -61,11 +110,55 @@ export async function handler(event: CloudWatchLogsEvent) {
       await cloudwatch
         .putMetricData({
           Namespace: 'AgentMonitoring',
-          MetricData: [generateFileLatencyMetricData(orgSlug, event)],
+          MetricData: [generateFileLatencyMetricData(orgSlug, event, pathsTrie)],
         })
         .promise()
     }
   }
+}
+
+async function getAgentConfiguration(
+  orgSlug: string,
+  authToken: string,
+  agentId: string,
+): Promise<AgentConfigurationApiResponse> {
+  let baseUrl = TETRASCIENCE_API_URL
+  if (!baseUrl?.endsWith('/')) {
+    baseUrl = baseUrl + '/'
+  }
+  const url = `${baseUrl}v1/agents/${agentId}/configuration`
+  const response = await axios.get(url, {
+    headers: {
+      'Content-Type': 'application/json',
+      'x-org-slug': orgSlug,
+      'ts-auth-token': authToken,
+    },
+  })
+  return response.data
+}
+
+interface PathTrieNode {
+  children: { [key: string]: PathTrieNode }
+  path?: string
+}
+
+function buildPathsTrie(paths: string[]): PathTrieNode {
+  const trie: PathTrieNode = { children: {} }
+  for (const path of paths) {
+    let node = trie
+    for (const segment of splitPath(path)) {
+      const segmentLower = segment.toLowerCase()
+      if (!node.children[segmentLower]) {
+        node.children[segmentLower] = { children: {} }
+      }
+      node = node.children[segmentLower]
+    }
+
+    if (node) {
+      node.path = path
+    }
+  }
+  return trie
 }
 
 // This function converts a string representing a timespan in the format `hh:mm:ss.ffffff` to milliseconds.
@@ -85,8 +178,9 @@ function generateFileLatencyMetricData(
   event: {
     timestamp: string
     component: { type: string; id: string }
-    data: { fileLastModifiedDate: string; fileCreateDate: string }
+    data: { osFilePath?: string; osFolderPath?: string; fileLastModifiedDate: string; fileCreateDate: string }
   },
+  pathsTrie: PathTrieNode,
 ): CloudWatch.MetricDatum {
   const fileLastModifiedDate = Date.parse(event.data.fileLastModifiedDate)
   const fileCreateDate = Date.parse(event.data.fileCreateDate)
@@ -94,19 +188,57 @@ function generateFileLatencyMetricData(
   const latencyStartDate = fileLastModifiedDate < fileCreateDate ? fileCreateDate : fileLastModifiedDate
   const latencyInSeconds = (Date.parse(event.timestamp) - latencyStartDate) / 1000
 
+  // determine the path this event is for using the paths trie
+  const filePath = event.data.osFilePath || event.data.osFolderPath || ''
+  let path = ''
+  let node = pathsTrie
+  for (const segment of splitPath(filePath)) {
+    const segmentLower = segment.toLowerCase()
+    if (!node.children[segmentLower]) {
+      break
+    }
+    node = node.children[segmentLower]
+    if (node.path) {
+      path = node.path
+      break
+    }
+  }
+
+  const dimensions = [
+    {
+      Name: 'orgSlug',
+      Value: orgSlug,
+    },
+    {
+      Name: 'agentId',
+      Value: event.component.id,
+    },
+  ]
+
+  if (path) {
+    dimensions.push({
+      Name: 'path',
+      Value: path,
+    })
+  }
+
   return {
     MetricName: 'FileUploadLatencyInSeconds',
-    Dimensions: [
-      {
-        Name: 'orgSlug',
-        Value: orgSlug,
-      },
-      {
-        Name: 'agentId',
-        Value: event.component.id,
-      },
-    ],
+    Dimensions: dimensions,
     Value: latencyInSeconds,
     Unit: 'Seconds',
   }
+}
+
+/**
+ * Splits a given path into an array of non-empty, trimmed segments.
+ *
+ * @param path - The path to split.
+ * @returns An array of path segments.
+ */
+function splitPath(path: string): string[] {
+  return path
+    .split('\\')
+    .map((segment) => segment.trim())
+    .filter((segment) => segment)
 }

--- a/test/ts-agent-monitoring-stack.fla-metrics-lambda.test.ts
+++ b/test/ts-agent-monitoring-stack.fla-metrics-lambda.test.ts
@@ -1,0 +1,140 @@
+import { processEvents } from '../lib/ts-agent-monitoring-stack.fla-metrics-lambda'
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+const mockPutMetricData = jest.fn((...args: any[]) => {
+  return {
+    promise: jest.fn().mockResolvedValue({}),
+  }
+})
+
+jest.mock('aws-sdk', () => {
+  return {
+    CloudWatch: function () {
+      return {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        putMetricData: (...args: any[]) => mockPutMetricData(...args),
+      }
+    },
+    SecretsManager: function () {
+      return {
+        getSecretValue: function () {
+          return {
+            promise: jest.fn().mockResolvedValue({ SecretString: 'test' }),
+          }
+        },
+      }
+    },
+  }
+})
+
+const mockGetAgentConfiguration = jest.fn()
+jest.mock('axios', () => {
+  return {
+    default: {
+      get: () => mockGetAgentConfiguration(),
+    },
+  }
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('path matched from configuration', async () => {
+  mockGetAgentConfiguration.mockResolvedValue(buildAgentConfigurationResponse(['c:\\test1\\', 'c:\\test2\\']))
+
+  const orgSlug = 'tetrascience'
+  const agentId = '55953bf0-acb6-4a45-beb6-cb30b33d4941'
+  await processEvents(`/agents/${orgSlug}/${agentId}`, [
+    {
+      message: JSON.stringify({
+        event: {
+          timestamp: '',
+          component: { id: agentId },
+          type: 'agents.filelog.fileUploadCompleted.v1',
+          data: { osFilePath: 'c:\\test1\\test.txt', fileLastModifiedDate: '', fileCreateDate: '' },
+        },
+      }),
+      id: '',
+      timestamp: 0,
+    },
+  ])
+
+  expect(mockPutMetricData).toHaveBeenCalledTimes(1)
+  const putMetricDataInput = mockPutMetricData.mock.calls[0][0]
+  expect(putMetricDataInput.Namespace).toBe('AgentMonitoring')
+  const metricData = putMetricDataInput.MetricData
+  expect(metricData.length).toBe(1)
+  expect(metricData[0].MetricName).toBe('FileUploadLatencyInSeconds')
+  expect(metricData[0].Unit).toBe('Seconds')
+  expect(metricData[0].Dimensions.length).toBe(3)
+  expect(metricData[0].Dimensions.find((d: { Name: string }) => d.Name === 'orgSlug')?.Value).toBe(orgSlug)
+  expect(metricData[0].Dimensions.find((d: { Name: string }) => d.Name === 'agentId')?.Value).toBe(agentId)
+  expect(metricData[0].Dimensions.find((d: { Name: string }) => d.Name === 'path')?.Value).toBe('c:\\test1\\')
+})
+
+function buildAgentConfigurationResponse(paths: string[]) {
+  return {
+    data: {
+      id: 'test',
+      by: 'local',
+      at: '2024-05-10T13:43:52.729Z',
+      config: {
+        services_configuration: {
+          fileWatcher: {
+            paths: paths.map((path) => ({ path })),
+          },
+        },
+      },
+    },
+  }
+}
+
+test('path matched after configuration change', async () => {
+  const orgSlug = 'tetrascience'
+  const agentId = '55953bf0-acb6-4a45-beb6-cb30b33d4941'
+
+  mockGetAgentConfiguration.mockResolvedValue(buildAgentConfigurationResponse(['c:\\test1\\', 'c:\\test2\\']))
+  await processEvents(`/agents/${orgSlug}/${agentId}`, [
+    {
+      message: JSON.stringify({
+        event: {
+          timestamp: '',
+          component: { id: agentId },
+          type: 'agents.filelog.fileUploadCompleted.v1',
+          data: { osFilePath: 'c:\\test1\\test.txt', fileLastModifiedDate: '', fileCreateDate: '' },
+        },
+      }),
+      id: '',
+      timestamp: 0,
+    },
+  ])
+
+  mockGetAgentConfiguration.mockResolvedValue(buildAgentConfigurationResponse(['c:\\test3\\']))
+  await processEvents(`/agents/${orgSlug}/${agentId}`, [
+    {
+      message: JSON.stringify({
+        event: {
+          timestamp: '',
+          component: { id: agentId },
+          type: 'agents.filelog.fileUploadCompleted.v1',
+          data: { osFilePath: 'c:\\test3\\test.txt', fileLastModifiedDate: '', fileCreateDate: '' },
+        },
+      }),
+      id: '',
+      timestamp: 0,
+    },
+  ])
+
+  expect(mockPutMetricData).toHaveBeenCalledTimes(2)
+  const putMetricDataInput = mockPutMetricData.mock.calls[1][0]
+  expect(putMetricDataInput.Namespace).toBe('AgentMonitoring')
+  const metricData = putMetricDataInput.MetricData
+  expect(metricData.length).toBe(1)
+  expect(metricData[0].MetricName).toBe('FileUploadLatencyInSeconds')
+  expect(metricData[0].Unit).toBe('Seconds')
+  expect(metricData[0].Dimensions.length).toBe(3)
+  expect(metricData[0].Dimensions.find((d: { Name: string }) => d.Name === 'orgSlug')?.Value).toBe(orgSlug)
+  expect(metricData[0].Dimensions.find((d: { Name: string }) => d.Name === 'agentId')?.Value).toBe(agentId)
+  expect(metricData[0].Dimensions.find((d: { Name: string }) => d.Name === 'path')?.Value).toBe('c:\\test3\\')
+})

--- a/test/ts-agent-monitoring.test.ts
+++ b/test/ts-agent-monitoring.test.ts
@@ -8,6 +8,8 @@ test('FLA Lambda and MetricFilters Created', () => {
   const agent2Id = '9cff0bce-119a-4fdd-aaf9-9201a1073bea'
   const agent3Id = 'f3691292-283b-4747-81dd-268dfe1229c8'
   const stack = new TsAgentMonitoring.TsAgentMonitoringStack(app, 'MyTestStack', {
+    tsApiUrl: '',
+    tsAuthToken: '',
     agents: [
       { id: agent1Id, orgSlug: 'test', type: 'file-log' },
       { id: agent2Id, orgSlug: 'test', type: 'file-log' },
@@ -48,6 +50,8 @@ test('Generate Metric documentation', () => {
   const app = new cdk.App()
   const agentId = 'b4a31b69-0719-4d05-9ded-5677df4be65f'
   const stack = new TsAgentMonitoring.TsAgentMonitoringStack(app, 'MyTestStack', {
+    tsApiUrl: '',
+    tsAuthToken: '',
     agents: [{ id: agentId, orgSlug: 'test', type: 'file-log' }],
   })
 


### PR DESCRIPTION
## JIRA Ticket
N/A

## Description of changes
Adds path dimension to FileUploadLatencyInSeconds metrics by matching `osFilePath` or `osFolderPath` against paths configured in agent.  Caches trie data structure used for matching in memory to improve performance and uses checksum of configuration to detect changes.

## Testing Completed

<!-- What type of test automation is included as part of this PR to ensure that the change is working as expected? !-->

- [x] Tested manually locally
- [x] Unit tests updated
- [ ] Integration tests updated
- [ ] Tested manually on platform with SSP
- [ ] None (please explain)

## Related information

<!--
Please list any related information here.
For example: links to other PRs, link to IDS, link to confluence docs, etc
--!>
